### PR TITLE
Fix assignment generation to preserve history

### DIFF
--- a/bd_rueda.sql
+++ b/bd_rueda.sql
@@ -22,7 +22,8 @@ CREATE TABLE asignaciones (
   id_asignacion INT AUTO_INCREMENT PRIMARY KEY,
   conjunto_asignaciones INT UNSIGNED NOT NULL DEFAULT 1,
   id_profesor INT NOT NULL,
-  id_modulo INT NOT NULL UNIQUE,
+  id_modulo INT NOT NULL,
+  UNIQUE KEY uk_conjunto_modulo (conjunto_asignaciones, id_modulo),
   FOREIGN KEY (id_profesor) REFERENCES profesores(id_profesor)
     ON DELETE CASCADE ON UPDATE CASCADE,
   FOREIGN KEY (id_modulo) REFERENCES modulos(id_modulo)


### PR DESCRIPTION
## Summary
- support multiple assignment sets by keeping prior assignments
- update DB schema so `id_modulo` isn't unique across sets
- redirect to the newly created set after generation

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587fc1e9448328aeb1f69cac9aa2d0