### PR TITLE
Agregar especialidad y atribución

### DIFF
--- a/bd_rueda.sql
+++ b/bd_rueda.sql
@@ -7,7 +7,8 @@ USE rueda;
 CREATE TABLE profesores (
   id_profesor INT AUTO_INCREMENT PRIMARY KEY,
   nombre VARCHAR(100) NOT NULL,
-  horas INT NOT NULL CHECK (horas >= 0)
+  horas INT NOT NULL CHECK (horas >= 0),
+  especialidad ENUM('Informática', 'SAI') NOT NULL
 );
 
 CREATE TABLE modulos (
@@ -16,7 +17,8 @@ CREATE TABLE modulos (
   abreviatura VARCHAR(20) NOT NULL,
   horas INT NOT NULL CHECK (horas > 0),
   curso ENUM('1º', '2º') NOT NULL,
-  ciclo ENUM('SMR', 'DAW', 'DAM', 'ASIR') NOT NULL
+  ciclo ENUM('SMR', 'DAW', 'DAM', 'ASIR') NOT NULL,
+  atribucion ENUM('Informática', 'SAI', 'Ambos') NOT NULL
 );
 
 CREATE TABLE asignaciones (


### PR DESCRIPTION
## Summary
- add `especialidad` enum to `profesores`
- add `atribucion` enum to `modulos`
- adjust forms and listings to manage the new fields
- update inserts and edits accordingly

## Testing
- `php -l index.php`
- `php -l asignaciones.php`
- `php -l db.php`


------
https://chatgpt.com/codex/tasks/task_e_6858939d36dc83289839dfafa2611eac