### PR TITLE
Increase border thickness for professor dropzones

### DIFF
--- a/asignaciones.php
+++ b/asignaciones.php
@@ -442,7 +442,7 @@ $colorClasses = [
                     <?php
                         $dropStyle = $d['profesor']['especialidad'] === 'Informática' ? 'border-solid' : 'border-dotted';
                     ?>
-                    <div class="dropzone p-2 border-2 border-black <?= $dropStyle ?> rounded-box bg-base-200 mb-2 flex flex-wrap gap-1 min-h-20" data-profesor-id="<?= $d['profesor']['id_profesor'] ?>" data-horas-meta="<?= $d['profesor']['horas'] ?>" data-especialidad="<?= $d['profesor']['especialidad'] ?>">
+                    <div class="dropzone p-2 border-4 border-black <?= $dropStyle ?> rounded-box bg-base-200 mb-2 flex flex-wrap gap-1 min-h-20" data-profesor-id="<?= $d['profesor']['id_profesor'] ?>" data-horas-meta="<?= $d['profesor']['horas'] ?>" data-especialidad="<?= $d['profesor']['especialidad'] ?>">
                         <span class="w-full text-center font-bold mb-2">
                             <?= htmlspecialchars($d['profesor']['nombre']) ?> (
                             <span class="total" data-profesor-id="<?= $d['profesor']['id_profesor'] ?>"><?= $d['total'] ?></span>/


### PR DESCRIPTION
## Summary
- adjust CSS class of professor dropzones so their border thickness matches module borders

## Testing
- `php -l asignaciones.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b297605b88328b963209d99d8c143