### PR TITLE
Align icons horizontally in tables

### DIFF
--- a/index.php
+++ b/index.php
@@ -203,7 +203,7 @@ $colorClasses = [
                                 <td><?= $p['horas'] ?></td>
                                 <td><?= $p['especialidad'] ?></td>
                                 <td><?= $p['numero_de_orden'] ?></td>
-                                <td class="space-x-2">
+                                <td class="flex items-center gap-2">
                                     <a href="?editar=<?= $p['id_profesor'] ?>&tipo=profesor" class="link link-primary"><img src="images/editar.svg" alt="Editar"></a>
                                     <a href="?eliminar=<?= $p['id_profesor'] ?>&tipo=profesor" class="link link-secondary" onclick="return confirm('¿Seguro que quieres eliminar este profesor?')"><img src="images/borrar.svg" alt="Eliminar"></a>
                                 </td>
@@ -295,7 +295,7 @@ $colorClasses = [
                                 <td><?= $m['curso'] ?></td>
                                 <td><?= $m['ciclo'] ?></td>
                                 <td><?= $m['atribucion'] ?></td>
-                                <td class="space-x-2">
+                                <td class="flex items-center gap-2">
                                     <a href="?editar=<?= $m['id_modulo'] ?>&tipo=modulo" class="link link-primary"><img src="images/editar.svg" alt="Editar"></a>
                                     <a href="?eliminar=<?= $m['id_modulo'] ?>&tipo=modulo" class="link link-secondary" onclick="return confirm('¿Seguro que quieres eliminar este módulo?')"><img src="images/borrar.svg" alt="Eliminar"></a>
                                 </td>


### PR DESCRIPTION
## Summary
- ensure edit/delete icons display on the same line in professor and module tables

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6700c5d88328a8dd92e89c657656