### PR TITLE
Implementa creación de nuevo conjunto en asignaciones

### DIFF
--- a/asignaciones.php
+++ b/asignaciones.php
@@ -291,12 +291,23 @@ if (
     exit;
 }
 
-$conjuntos = $pdo->query("SELECT DISTINCT conjunto_asignaciones FROM asignaciones ORDER BY conjunto_asignaciones")->fetchAll(PDO::FETCH_COLUMN);
-$seleccionado = isset($_GET['conjunto']) ? (int)$_GET['conjunto'] : null;
-// Si no se ha elegido ningún conjunto, generar uno nuevo para permitir asignaciones manuales
+$conjuntos = $pdo->query(
+    "SELECT DISTINCT conjunto_asignaciones FROM asignaciones ORDER BY conjunto_asignaciones"
+)->fetchAll(PDO::FETCH_COLUMN);
+$seleccionado = isset($_GET["conjunto"]) ? (int)$_GET["conjunto"] : null;
+// Si se accede sin conjunto especificado, obtener el siguiente número disponible
+// para comenzar una asignación vacía
 if ($seleccionado === null) {
-    $seleccionado = (int)$pdo->query("SELECT IFNULL(MAX(conjunto_asignaciones), 0) + 1 FROM asignaciones")->fetchColumn();
+    $seleccionado = (int)$pdo
+        ->query("SELECT IFNULL(MAX(conjunto_asignaciones), 0) + 1 FROM asignaciones")
+        ->fetchColumn();
+    // Añadir el nuevo conjunto a la lista para que se muestre como disponible
+    if (!in_array($seleccionado, $conjuntos, true)) {
+        $conjuntos[] = $seleccionado;
+        sort($conjuntos);
+    }
 }
+
 
 $profesores = $pdo->query(
     "SELECT * FROM profesores ORDER BY CASE especialidad WHEN 'Informática' THEN 1 WHEN 'SAI' THEN 2 ELSE 3 END, numero_de_orden"


### PR DESCRIPTION
## Summary
- al entrar a asignaciones sin parámetro se calcula el siguiente número de conjunto disponible
- el nuevo conjunto se añade al listado para empezar con módulos vacíos

## Testing
- `php -l asignaciones.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c9d2d19248328ad0db78e542b6b35