### PR TITLE
Fix PHP syntax for older versions

### DIFF
--- a/asignaciones.php
+++ b/asignaciones.php
@@ -237,7 +237,9 @@ if (
             $target[] = $m;
         }
 
-        $sortHoras = fn($a, $b) => $b['horas'] <=> $a['horas'];
+        $sortHoras = function ($a, $b) {
+            return $b['horas'] <=> $a['horas'];
+        };
         foreach ([$saiNorm, $saiFct, $infNorm, $infFct, $ambNorm, $ambFct] as &$arr) {
             usort($arr, $sortHoras);
         }
@@ -316,20 +318,20 @@ if (
         };
 
         // 1. Módulos SAI a profesores SAI
-        $asignarLista($saiNorm, fn($p) => $p['especialidad'] === 'SAI');
-        $asignarLista($saiFct, fn($p) => $p['especialidad'] === 'SAI');
+        $asignarLista($saiNorm, function ($p) { return $p['especialidad'] === 'SAI'; });
+        $asignarLista($saiFct, function ($p) { return $p['especialidad'] === 'SAI'; });
 
         // 2. Módulos Informática a profesores de Informática
-        $asignarLista($infNorm, fn($p) => $p['especialidad'] === 'Informática');
-        $asignarLista($infFct, fn($p) => $p['especialidad'] === 'Informática');
+        $asignarLista($infNorm, function ($p) { return $p['especialidad'] === 'Informática'; });
+        $asignarLista($infFct, function ($p) { return $p['especialidad'] === 'Informática'; });
 
         // 3. Completar SAI con módulos "Ambos"
-        $asignarLista($ambNorm, fn($p) => $p['especialidad'] === 'SAI');
-        $asignarLista($ambFct, fn($p) => $p['especialidad'] === 'SAI');
+        $asignarLista($ambNorm, function ($p) { return $p['especialidad'] === 'SAI'; });
+        $asignarLista($ambFct, function ($p) { return $p['especialidad'] === 'SAI'; });
 
         // 4. Restantes módulos SAI y "Ambos" a Informática
         $restantes = array_merge($saiNorm, $saiFct, $ambNorm, $ambFct);
-        $asignarLista($restantes, fn($p) => $p['especialidad'] === 'Informática');
+        $asignarLista($restantes, function ($p) { return $p['especialidad'] === 'Informática'; });
 
         $pdo->commit();
     } catch (Exception $e) {

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ $ciclos = [];
 $stmt = $pdo->query("SHOW COLUMNS FROM modulos LIKE 'ciclo'");
 $col = $stmt->fetch(PDO::FETCH_ASSOC);
 if ($col && isset($col['Type']) && preg_match("/^enum\((.*)\)$/", $col['Type'], $m)) {
-    $ciclos = array_map(fn($v) => trim($v, "' "), explode(',', $m[1]));
+    $ciclos = array_map(function ($v) { return trim($v, "' "); }, explode(',', $m[1]));
 }
 
 // Posibles valores para especialidad de profesores
@@ -25,7 +25,7 @@ $especialidades = [];
 $stmt = $pdo->query("SHOW COLUMNS FROM profesores LIKE 'especialidad'");
 $col = $stmt->fetch(PDO::FETCH_ASSOC);
 if ($col && isset($col['Type']) && preg_match("/^enum\((.*)\)$/", $col['Type'], $m)) {
-    $especialidades = array_map(fn($v) => trim($v, "' "), explode(',', $m[1]));
+    $especialidades = array_map(function ($v) { return trim($v, "' "); }, explode(',', $m[1]));
 }
 
 // Posibles valores para atribución de módulos
@@ -33,7 +33,7 @@ $atribuciones = [];
 $stmt = $pdo->query("SHOW COLUMNS FROM modulos LIKE 'atribucion'");
 $col = $stmt->fetch(PDO::FETCH_ASSOC);
 if ($col && isset($col['Type']) && preg_match("/^enum\((.*)\)$/", $col['Type'], $m)) {
-    $atribuciones = array_map(fn($v) => trim($v, "' "), explode(',', $m[1]));
+    $atribuciones = array_map(function ($v) { return trim($v, "' "); }, explode(',', $m[1]));
 }
 
 // ELIMINAR


### PR DESCRIPTION
## Summary
- replace PHP 7.4 arrow functions with classic anonymous functions

## Testing
- `php -l asignaciones.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca6a3705c8328bb1f939d889dbf9c