### PR TITLE
Fix PHP syntax for reference assignment

### DIFF
--- a/asignaciones.php
+++ b/asignaciones.php
@@ -228,11 +228,23 @@ if (
             $m['__fct'] = $esFct;
             $target =& $ambNorm; // default
             if ($m['atribucion'] === 'SAI') {
-                $target =& ($esFct ? $saiFct : $saiNorm);
+                if ($esFct) {
+                    $target =& $saiFct;
+                } else {
+                    $target =& $saiNorm;
+                }
             } elseif ($m['atribucion'] === 'Informática') {
-                $target =& ($esFct ? $infFct : $infNorm);
+                if ($esFct) {
+                    $target =& $infFct;
+                } else {
+                    $target =& $infNorm;
+                }
             } else { // Ambos
-                $target =& ($esFct ? $ambFct : $ambNorm);
+                if ($esFct) {
+                    $target =& $ambFct;
+                } else {
+                    $target =& $ambNorm;
+                }
             }
             $target[] = $m;
         }


### PR DESCRIPTION
## Summary
- fix invalid reference assignment using ternary operator

## Testing
- `php -l asignaciones.php`

------
https://chatgpt.com/codex/tasks/task_e_685ca7e3e81c8328bbbe129a9f9be25f